### PR TITLE
fix: Compilation with ZTS enabled (GH-60)

### DIFF
--- a/disable-eval.c
+++ b/disable-eval.c
@@ -146,7 +146,10 @@ static zend_op_array* zend_compile_string_override(
 #endif
 )
 {
-    static const eval_pattern_t patterns[] = {
+#ifndef ZTS
+    static
+#endif
+    const eval_pattern_t patterns[] = {
         { ZEND_STRL(" : eval()'d code"),            "eval()",                           &DE_G(enabled)      },
 #if PHP_VERSION_ID < 80000
         { ZEND_STRL(" : runtime-created function"), "create_function()",                &DE_G(enabled)      },


### PR DESCRIPTION
```c
static const eval_pattern_t patterns[] = {
    { ZEND_STRL(" : eval()'d code"), "eval()", &DE_G(enabled) },
    /* ... */
};

/* ... */


#define DE_G(v) TSRMG(de_globals_id, zend_de_globals*, v)

/* ... */

#define TSRMG(id, type, element)	(TSRMG_BULK(id, type)->element)
#define TSRMG_BULK(id, type)	((type) (*((void ***) tsrm_get_ls_cache()))[TSRM_UNSHUFFLE_RSRC_ID(id)])
```

`tsrm_get_ls_cache()` cannot be used if `patterns` is `static`.